### PR TITLE
Add One Time Login and Server Group Support

### DIFF
--- a/modules/servers/hostedai/assets/js/custom.js
+++ b/modules/servers/hostedai/assets/js/custom.js
@@ -1,0 +1,78 @@
+// OTL (One Time Login) functionality
+function generateOTLAndLogin(button, serviceId, userEmail, staticLoginUrl) {
+    // Disable button and show loading state
+    button.disabled = true;
+    const originalText = button.textContent;
+    button.textContent = 'Generating...';
+    
+    // Prepare AJAX request
+    const formData = new FormData();
+    formData.append('action', 'generate_otl');
+    formData.append('service_id', serviceId);
+    formData.append('user_email', userEmail);
+    formData.append('static_login_url', staticLoginUrl);
+    
+    fetch('/modules/servers/hostedai/lib/ajax.php', {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success && data.login_url) {
+            // Success - redirect to OTL URL
+            window.open(data.login_url, '_blank');
+        } else {
+            // Show error message briefly
+            if (data.message) {
+                button.textContent = data.message;
+                setTimeout(() => {
+                    button.textContent = originalText;
+                    button.disabled = false;
+                }, 3000);
+            }
+            
+            // Fallback to static URL if available
+            if (data.fallback_url && data.fallback_url !== '#') {
+                setTimeout(() => {
+                    const fallbackUrl = data.fallback_url.startsWith('http') ? data.fallback_url : 'https://' + data.fallback_url;
+                    window.open(fallbackUrl, '_blank');
+                }, 3500);
+            } else {
+                // Re-enable button if no fallback
+                setTimeout(() => {
+                    button.textContent = originalText;
+                    button.disabled = false;
+                }, 3000);
+            }
+        }
+    })
+    .catch(error => {
+        console.error('OTL Generation Error:', error);
+        button.textContent = 'Error occurred. Using standard login.';
+        
+        // Fallback to static URL
+        setTimeout(() => {
+            if (staticLoginUrl && staticLoginUrl !== '#') {
+                const fallbackUrl = staticLoginUrl.startsWith('http') ? staticLoginUrl : 'https://' + staticLoginUrl;
+                window.open(fallbackUrl, '_blank');
+            } else {
+                button.textContent = originalText;
+                button.disabled = false;
+            }
+        }, 2000);
+    });
+}
+
+// Initialize OTL buttons when DOM is ready
+document.addEventListener('DOMContentLoaded', function() {
+    const otlButtons = document.querySelectorAll('.otl-login-btn');
+    otlButtons.forEach(button => {
+        button.addEventListener('click', function(e) {
+            e.preventDefault();
+            const serviceId = this.getAttribute('data-service-id');
+            const userEmail = this.getAttribute('data-user-email');
+            const staticLoginUrl = this.getAttribute('data-static-url');
+            generateOTLAndLogin(this, serviceId, userEmail, staticLoginUrl);
+        });
+    });
+});

--- a/modules/servers/hostedai/assets/js/custom.js
+++ b/modules/servers/hostedai/assets/js/custom.js
@@ -12,7 +12,7 @@ function generateOTLAndLogin(button, serviceId, userEmail, staticLoginUrl) {
     formData.append('user_email', userEmail);
     formData.append('static_login_url', staticLoginUrl);
     
-    fetch('/modules/servers/hostedai/lib/ajax.php', {
+    fetch('./modules/servers/hostedai/lib/ajax.php', {
         method: 'POST',
         body: formData
     })
@@ -48,6 +48,7 @@ function generateOTLAndLogin(button, serviceId, userEmail, staticLoginUrl) {
     })
     .catch(error => {
         console.error('OTL Generation Error:', error);
+        console.error('Error details:', error.message);
         button.textContent = 'Error occurred. Using standard login.';
         
         // Fallback to static URL

--- a/modules/servers/hostedai/hostedai.php
+++ b/modules/servers/hostedai/hostedai.php
@@ -22,8 +22,58 @@ function hostedai_ConfigOptions(array $params)
 {   
 
     global $whmcs;
-    $helper = new Helper();
+    
+    // Get the product ID
     $pid = $whmcs->get_req_var("id");
+    
+    // Try to get server information based on the product's server group
+    $serverParams = [];
+    
+    // Debug logging removed - functionality working correctly
+    
+    if ($pid) {
+        try {
+            // Get the product details
+            $product = Capsule::table('tblproducts')->where('id', $pid)->first();
+            
+            if ($product) {
+                $productServerGroup = $product->servergroup ?: 0;
+                
+                // Also check if servergroup is being passed in the request
+                $requestServerGroup = 0;
+                if (isset($_GET['servergroup']) && $_GET['servergroup']) {
+                    $requestServerGroup = $_GET['servergroup'];
+                }
+                
+                $serverGroupToUse = $requestServerGroup ?: $productServerGroup;
+                
+                if ($serverGroupToUse > 0) {
+                    // In WHMCS, server groups are managed through tblservergroupsrel table
+                    // We need to join tblservers with tblservergroupsrel to find servers in a group
+                    // Get enabled servers from the assigned server group
+                    $server = Capsule::table('tblservers')
+                        ->join('tblservergroupsrel', 'tblservers.id', '=', 'tblservergroupsrel.serverid')
+                        ->where('tblservergroupsrel.groupid', $serverGroupToUse)
+                        ->where('tblservers.type', 'hostedai')
+                        ->where('tblservers.disabled', 0)
+                        ->select('tblservers.*')
+                        ->first();
+                    
+                    if ($server) {
+                        $serverParams = [
+                            'serverhostname' => $server->hostname,
+                            'serverpassword' => decrypt($server->password)
+                        ];
+                    }
+                }
+            }
+        } catch (Exception $e) {
+            // Log error but continue with default behavior
+            logActivity('hostedai_ConfigOptions error', $e->getMessage());
+        }
+    }
+    
+    $helper = new Helper($serverParams);
 
     /** Get the API to fetch the pricing policy items */
     $getPricingPolicy = $helper->getPolicyItems('pricing-policy');

--- a/modules/servers/hostedai/hostedai.php
+++ b/modules/servers/hostedai/hostedai.php
@@ -624,7 +624,7 @@ function hostedai_AdminServicesTabFields(array $params)
                                     <td style="width:50%" class="hading-td">
                                         <div class="hosting-information">
                                             <div class="panel panel-primary">
-                                                <div class="panel-heading"><p>Resource Overview</p> <p>'.$is_suspend.' <a href="'.$loginURL.'" target="_blank" class="btn btn-primary">Login</a></p> </div>
+                                                <div class="panel-heading"><p>Resource Overview</p> <p>'.$is_suspend.'</p> </div>
                                                 <div class="panel-body overview-main">
                                                     <div class="row">
                                                         '.$resourceHTML.'
@@ -749,6 +749,8 @@ function hostedai_ClientArea(array $params)
                             'teammembers' => $getTeamMembers ? $getTeamMembers['result']->members : '',
                             'resourcesData' => $resourceOverviewData,
                             'loginURL' => $loginURL,
+                            'serviceId' => $params['serviceid'],
+                            'userEmail' => $params['clientsdetails']['email'],
                             'assets' => $assets,
                             'LANG' => $_ADDONLANG
                         ),

--- a/modules/servers/hostedai/lib/Helper.php
+++ b/modules/servers/hostedai/lib/Helper.php
@@ -66,7 +66,7 @@ class Helper
 
             $baseUrl = $this->baseUrl;
             $getUrl =  $baseUrl . $endPoint;
-            $curlResponse = $this->curlCall("GET", $getUrl, "getPolicyItems", $endPoint);
+            $curlResponse = $this->curlCall("GET", "getPolicyItems", $endPoint, $getUrl);
 
             return $curlResponse;
         } catch (Exception $e) {
@@ -79,7 +79,7 @@ class Helper
     {
         try {
             $endPoint = 'team';
-            $curlResponse = $this->curlCall("POST", $apiData, "createHostedaiTeam", $endPoint);
+            $curlResponse = $this->curlCall("POST", "createHostedaiTeam", $endPoint, $apiData);
 
             return $curlResponse;
         } catch (Exception $e) {
@@ -92,7 +92,7 @@ class Helper
     {
         try {
             $endPoint = 'team/' . $teamid;
-            $curlResponse = $this->curlCall("GET", '', "getTeamDetail", $endPoint);
+            $curlResponse = $this->curlCall("GET", "getTeamDetail", $endPoint, '');
 
             return $curlResponse;
         } catch (Exception $e) {
@@ -105,7 +105,7 @@ class Helper
     {
         try {
             $endPoint = 'team/' . $teamid . '/members?page=1&itemsPerPage=50';
-            $curlResponse = $this->curlCall("GET", '', "getTeamMembers", $endPoint);
+            $curlResponse = $this->curlCall("GET", "getTeamMembers", $endPoint, '');
 
             return $curlResponse;
         } catch (Exception $e) {
@@ -118,7 +118,7 @@ class Helper
     {
         try {
             $endPoint = 'team/' . $teamid . '/resource-overview';
-            $curlResponse = $this->curlCall("GET", '', "getTeamMembers", $endPoint);
+            $curlResponse = $this->curlCall("GET", "getResourceOverview", $endPoint, '');
 
             return $curlResponse;
         } catch (Exception $e) {
@@ -131,7 +131,7 @@ class Helper
     {
         try {
             $endPoint = 'team/' . $teamid . '/suspend';
-            $curlResponse = $this->curlCall("POST", '', "suspendHostedaiTeam", $endPoint);
+            $curlResponse = $this->curlCall("POST", "suspendHostedaiTeam", $endPoint, '');
 
             return $curlResponse;
         } catch (Exception $e) {
@@ -144,7 +144,7 @@ class Helper
     {
         try {
             $endPoint = 'team/' . $teamid . '/unsuspend';
-            $curlResponse = $this->curlCall("POST", '', "unsuspendHostedaiTeam", $endPoint);
+            $curlResponse = $this->curlCall("POST", "unsuspendHostedaiTeam", $endPoint, '');
 
             return $curlResponse;
         } catch (Exception $e) {
@@ -157,7 +157,7 @@ class Helper
     {
         try {
             $endPoint = 'team/' . $teamid;
-            $curlResponse = $this->curlCall("DELETE", '', "terminateHostedaiTeam", $endPoint);
+            $curlResponse = $this->curlCall("DELETE", "terminateHostedaiTeam", $endPoint, '');
 
             return $curlResponse;
         } catch (Exception $e) {
@@ -518,8 +518,25 @@ class Helper
         }
     }
 
+    /** Create One Time Login Token */
+    public function createOneTimeLoginToken($userEmail)
+    {
+        try {
+            $endPoint = 'create-otl';
+            $data = [
+                'email' => $userEmail,
+                'send_email_invite' => false  // We just want the URL, not to send email
+            ];
+            $curlResponse = $this->curlCall("POST", "createOneTimeLoginToken", $endPoint, $data);
+            return $curlResponse;
+        } catch (Exception $e) {
+            logActivity('Unable to create OTL token, Error: ', $e->getMessage());
+            return ['httpcode' => 500, 'result' => null];
+        }
+    }
+
     /* Retrieve the Curl API response.*/
-    public function curlCall($method, $data = null, $action, $endpoint = null)
+    public function curlCall($method, $action, $endpoint = null, $data = null)
     {
 
         $baseUrl = $this->baseUrl;

--- a/modules/servers/hostedai/lib/ajax.php
+++ b/modules/servers/hostedai/lib/ajax.php
@@ -1,0 +1,94 @@
+<?php
+
+use WHMCS\Module\Server\HosteDai\Helper;
+use WHMCS\Database\Capsule;
+
+if (!defined("WHMCS")) {
+    die("This file cannot be accessed directly");
+}
+
+// Handle AJAX requests
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    
+    if ($action === 'generate_otl') {
+        generateOTL();
+    }
+}
+
+function generateOTL() {
+    try {
+        $serviceId = $_POST['service_id'] ?? '';
+        $userEmail = $_POST['user_email'] ?? '';
+        $staticLoginUrl = $_POST['static_login_url'] ?? '';
+        
+        if (empty($serviceId) || empty($userEmail)) {
+            echo json_encode([
+                'success' => false,
+                'message' => 'Missing required parameters',
+                'fallback_url' => $staticLoginUrl
+            ]);
+            return;
+        }
+        
+        // Get service details to retrieve server configuration
+        $service = Capsule::table('tblhosting')->where('id', $serviceId)->first();
+        if (!$service) {
+            echo json_encode([
+                'success' => false,
+                'message' => 'Service not found',
+                'fallback_url' => $staticLoginUrl
+            ]);
+            return;
+        }
+        
+        // Get server details
+        $server = Capsule::table('tblservers')->where('id', $service->server)->first();
+        if (!$server) {
+            echo json_encode([
+                'success' => false,
+                'message' => 'Server configuration not found',
+                'fallback_url' => $staticLoginUrl
+            ]);
+            return;
+        }
+        
+        // Create helper with server params
+        $params = [
+            'serverhostname' => $server->hostname,
+            'serverpassword' => decrypt($server->password)
+        ];
+        
+        $helper = new Helper($params);
+        $otlResponse = $helper->createOneTimeLoginToken($userEmail);
+        
+        if ($otlResponse && $otlResponse['httpcode'] == 201 && isset($otlResponse['result']->url)) {
+            echo json_encode([
+                'success' => true,
+                'login_url' => $otlResponse['result']->url,
+                'message' => 'One-time login link generated successfully'
+            ]);
+        } else {
+            // Log the error for debugging
+            $errorMsg = 'OTL generation failed';
+            if (isset($otlResponse['result']->message)) {
+                $errorMsg .= ': ' . $otlResponse['result']->message;
+            }
+            logActivity('OTL Generation Failed', $errorMsg);
+            
+            echo json_encode([
+                'success' => false,
+                'message' => 'Unable to generate secure login link. Using standard login.',
+                'fallback_url' => $staticLoginUrl
+            ]);
+        }
+        
+    } catch (Exception $e) {
+        logActivity('OTL AJAX Error', $e->getMessage());
+        echo json_encode([
+            'success' => false,
+            'message' => 'An error occurred. Using standard login.',
+            'fallback_url' => $staticLoginUrl
+        ]);
+    }
+}

--- a/modules/servers/hostedai/lib/ajax.php
+++ b/modules/servers/hostedai/lib/ajax.php
@@ -1,11 +1,39 @@
 <?php
 
+// Set headers for AJAX response
+header('Content-Type: application/json');
+
+// Initialize WHMCS if not already done
+if (!defined('WHMCS')) {
+    $possiblePaths = [
+        dirname(dirname(dirname(dirname(__FILE__)))) . '/init.php',
+        '../../../init.php',
+        '../../../../init.php',
+        dirname($_SERVER['DOCUMENT_ROOT']) . '/init.php',
+        $_SERVER['DOCUMENT_ROOT'] . '/init.php'
+    ];
+    
+    $whmcsInitialized = false;
+    foreach ($possiblePaths as $path) {
+        if (file_exists($path)) {
+            require_once $path;
+            $whmcsInitialized = true;
+            break;
+        }
+    }
+    
+    if (!$whmcsInitialized) {
+        echo json_encode([
+            'success' => false, 
+            'message' => 'WHMCS initialization failed',
+            'debug' => 'Tried paths: ' . implode(', ', $possiblePaths)
+        ]);
+        exit;
+    }
+}
+
 use WHMCS\Module\Server\HosteDai\Helper;
 use WHMCS\Database\Capsule;
-
-if (!defined("WHMCS")) {
-    die("This file cannot be accessed directly");
-}
 
 // Handle AJAX requests
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -13,7 +41,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     
     if ($action === 'generate_otl') {
         generateOTL();
+    } else {
+        echo json_encode(['success' => false, 'message' => 'Invalid action']);
     }
+} else {
+    echo json_encode(['success' => false, 'message' => 'Invalid request method']);
 }
 
 function generateOTL() {

--- a/modules/servers/hostedai/templates/manage.tpl
+++ b/modules/servers/hostedai/templates/manage.tpl
@@ -6,7 +6,7 @@
 <div class="container">
 
     <div class="panel panel-primary">
-        <div class="panel-heading"><p>Overview</p> <a href="{if strpos($loginURL, 'http') !== 0}https://{/if}{$loginURL}" target="_blank" class="btn btn-primary">Login</a> </div>
+        <div class="panel-heading"><p>Overview</p> <button class="btn btn-primary otl-login-btn" data-service-id="{$serviceId}" data-user-email="{$userEmail}" data-static-url="{$loginURL}">Login</button> </div>
         <div class="panel-body overview-main">
             <div class="row">
                 {foreach from=$resourcesData key=key item=item}


### PR DESCRIPTION
- Added support for One Time Login links on the client panel. If the OTL URL cannot be retrieved the prior behaviour with a basic login link to the user panel login URL will be used. 
- Removed redundant 'Login' link from the admin view. 
- Fixed Server Group Support so multiple hosted.ai user panels could be connected with the same WHMCS instance.