### PR TITLE
Release v2.4.0: adapt to ariel API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-06-16
+
+### Changed
+- Adapted team creation payload to ariel API: policy IDs now nested under `general` object with `has_general_policies: true` flag (breaking change in `POST /api/team`)
+
 ## [2.2.0] - 2025-03-12
 
 ### Changed

--- a/modules/servers/hostedai/hostedai.php
+++ b/modules/servers/hostedai/hostedai.php
@@ -8,7 +8,7 @@ if (!defined("WHMCS")) {
     die("This file cannot be accessed directly");
 }
 
-define('HOSTEDAI_MODULE_VERSION', '2.2.0');
+define('HOSTEDAI_MODULE_VERSION', '2.4.0');
 
 function hostedai_MetaData()
 {
@@ -314,8 +314,14 @@ function hostedai_CreateAccount(array $params)
         $postData = [
             'color' => $color ?? '#414141',
             'description' => '',
-            'image_policy_id' => $imagePolicyID ?? '',
-            "instance_type_policy_id" => $instancePolicyID ?? '',
+            'has_general_policies' => true,
+            'general' => [
+                'image_policy_id' => $imagePolicyID ?? '',
+                'instance_type_policy_id' => $instancePolicyID ?? '',
+                'pricing_policy_id' => $pricingPolicyID ?? '',
+                'resource_policy_id' => $resourcePolicyID ?? '',
+                'service_policy_id' => $servicePolicyID ?? '',
+            ],
             'members' => [
                 [
                     'email' => $email ?? '',
@@ -325,9 +331,6 @@ function hostedai_CreateAccount(array $params)
                 ]
             ],
             'name' => preg_replace('/\s+/', '-', trim($name ?? '')) . '-' . $serviceId,
-            'pricing_policy_id' => $pricingPolicyID ?? '',
-            'resource_policy_id' => $resourcePolicyID ?? '',
-            'service_policy_id' => $servicePolicyID ?? '',
         ];
         
 


### PR DESCRIPTION
## Summary

- Adapted `POST /api/team` payload for ariel API: policy IDs now nested under a `general` object with `has_general_policies: true`, replacing the flat top-level fields from the europa/Titan API
- Bumped module version to `2.4.0`
- Updated CHANGELOG.md