### PR TITLE
chore(release): 2.4.2 — document WHMCS 9.0 / PHP 8.2+ requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.4.2] - 2026-07-11
+
+> Module-only patch on top of platform **2.4.1** (ariel_1) — no API/platform change; the third digit tracks module iterations under SemVer.
+
+### Documentation
+- Documented the **WHMCS 9.0 / PHP 8.2+ requirement**. WHMCS 9.0 dropped PHP 8.1, so a cron left on PHP 8.1 fails silently with `cannot be run by the ionCube Loader … PHP 8.1` and stops billing. Updated the Administrator Guide requirements (WHMCS 8.x–9.x; PHP 8.2/8.3/8.4 on 9.0; ionCube Loader must be enabled for the **CLI** SAPI, not just the web server), added a "use the right PHP binary" note with a verify command (`php -r 'require ".../init.php"; echo "OK";'`) to the cron-setup step, and added a troubleshooting entry for the ionCube error. README cron example carries the same note. Sourced from the official [WHMCS 9.0 system requirements](https://docs.whmcs.com/9-0/installation-guide/system-requirements/).
+
 ## [2.4.1] - 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ You will need to set up a custom cron job to generate bills and create invoices,
 For example:
 0 0 * * * /usr/bin/php8.3 /var/www/clients/client1/web1/web/crons/hostedai_cron.php
 
+> **PHP version for the cron:** use a CLI PHP your WHMCS supports, with the ionCube
+> Loader enabled for CLI. **WHMCS 9.0 requires PHP 8.2+** (8.2/8.3/8.4) and does **not**
+> run on 8.1 — a cron on the wrong version fails silently with an ionCube error. See the
+> [Administrator Guide → Requirements](docs/ADMINISTRATOR_GUIDE.md#requirements).
+
 ![image](https://github.com/user-attachments/assets/2660bcf7-6b6c-48a2-82aa-cc9767ae40ef)
 
 Now you can select the hosted·ai specific details

--- a/docs/ADMINISTRATOR_GUIDE.md
+++ b/docs/ADMINISTRATOR_GUIDE.md
@@ -3,7 +3,7 @@
 Complete reference for installing, configuring, and operating the hosted·ai server
 module, including the prepaid wallet system introduced in v2.x.
 
-**Compatibility:** WHMCS 8.x · PHP 8.1+ · Module type: Server
+**Compatibility:** WHMCS 8.x–9.x · PHP 8.1+ (WHMCS 9.0 requires **PHP 8.2+**) · ionCube Loader · Module type: Server
 
 ---
 
@@ -59,8 +59,9 @@ service's custom fields.
 
 | Component | Minimum | Notes |
 |---|---|---|
-| WHMCS | 8.0 | Tested on 8.10–8.12 |
-| PHP | 8.1 | 8.2+ supported |
+| WHMCS | 8.0 | Tested on 8.10–8.12 and 9.0 |
+| PHP | 8.1 on WHMCS 8.x · **8.2** on WHMCS 9.0 | Use the version your WHMCS requires. **WHMCS 9.0 dropped PHP 8.1** — it needs 8.2 / 8.3 / 8.4 ([WHMCS 9.0 requirements](https://docs.whmcs.com/9-0/installation-guide/system-requirements/)). |
+| ionCube Loader | Required | Match the loader to your PHP version, and enable it for the **CLI** SAPI too — the cron runs under CLI, not only the web server. |
 | MySQL / MariaDB | 5.7 / 10.3 | Module creates its own table on first use |
 | hosted·ai API | Current | API token with admin privileges required |
 | Cron access | — | Server-level crontab or WHMCS cron hook |
@@ -106,6 +107,19 @@ root to match your environment.
 # Hourly billing + balance checks — runs every hour
 0 * * * * /usr/bin/php /var/www/whmcs/crons/hostedai_hourly_cron.php
 ```
+
+> **Use the right PHP binary.** The cron runs under the **CLI** PHP, which must be a
+> version your WHMCS supports (WHMCS 9.0: **8.2 / 8.3 / 8.4**) with the **ionCube Loader
+> enabled for CLI**. `/usr/bin/php` is often a different (or unsupported) version, so set
+> the full path explicitly (e.g. `/usr/bin/php8.3`). Verify a binary can bootstrap WHMCS
+> before scheduling it:
+>
+> ```bash
+> /path/to/php -r 'require "/path/to/whmcs/init.php"; echo "OK";'
+> ```
+>
+> `OK` = usable. `cannot be run by the ionCube Loader … PHP 8.x` means that version is
+> unsupported or missing the CLI ionCube Loader — pick a supported one.
 
 See [Cron Jobs](#cron-jobs) for what each script does.
 
@@ -547,6 +561,13 @@ non-zero resource usage in the hosted·ai API.
 `hostedai_AdminServicesTabFields` regardless of whether the hosted·ai API is
 reachable. If absent, check the PHP error log for exceptions and verify the module
 files are uploaded and readable.
+
+**Billing crons do nothing / cron log shows `cannot be run by the ionCube Loader … PHP 8.1`.**
+The crontab entry is running under a PHP version your WHMCS does not support — most
+often after upgrading to WHMCS 9.0, which dropped PHP 8.1. Point the crontab at a
+supported CLI PHP with the ionCube Loader enabled (WHMCS 9.0: 8.2 / 8.3 / 8.4) — see
+[Register cron jobs](#2-register-cron-jobs) for the verification command. See also
+[WHMCS: Troubleshooting ionCube Errors](https://help.whmcs.com/m/troubleshooting/l/700394-troubleshooting-ioncube-errors).
 
 > **Activity log.** All cron actions and mode switches are written to the WHMCS
 > activity log (**Utilities → Logs → Activity Log**). Search for `hostedai` or

--- a/modules/servers/hostedai/hostedai.php
+++ b/modules/servers/hostedai/hostedai.php
@@ -8,7 +8,7 @@ if (!defined("WHMCS")) {
     die("This file cannot be accessed directly");
 }
 
-define('HOSTEDAI_MODULE_VERSION', '2.4.1');
+define('HOSTEDAI_MODULE_VERSION', '2.4.2');
 
 function hostedai_MetaData()
 {


### PR DESCRIPTION
Patch release **2.4.2** (module patch on platform 2.4.1). Docs-only + version bump.

**Why:** WHMCS 9.0 dropped PHP 8.1 — a cron left on 8.1 fails with `cannot be run by the ionCube Loader … PHP 8.1` and silently stops billing. Our docs previously said `PHP 8.1+`, which misleads WHMCS 9 users.

**Changes**
- `ADMINISTRATOR_GUIDE`: Requirements now list WHMCS 8.x–9.x, PHP 8.2/8.3/8.4 on 9.0, and a dedicated **ionCube Loader (CLI SAPI)** row; a "use the right PHP binary" note with a verify command (`php -r 'require ".../init.php"; echo "OK";'`) in the cron-setup step; a troubleshooting entry for the ionCube error.
- `README`: same PHP-version note on the cron example.
- `HOSTEDAI_MODULE_VERSION` 2.4.1 → 2.4.2; CHANGELOG `[2.4.2]`.

Sourced from the official [WHMCS 9.0 system requirements](https://docs.whmcs.com/9-0/installation-guide/system-requirements/). No code/behaviour change.