### PR TITLE
fix(prepaid): suspend when wallet can't cover the hour + clearer config labels (2.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.4.3] - 2026-07-11
+
+### Fixed
+- **Prepaid: suspend when the wallet can no longer cover an hour** — previously a prepaid service with an insufficient wallet was **never suspended** and ran for free while unpayable invoices piled up hourly. WHMCS `ApplyCredit` is all-or-nothing, so a full hourly charge against a short balance failed entirely: the balance never reached the min-balance floor and the `balance ≤ min` suspend never fired. Now `Helper::createAndPayHourlyInvoice()` checks the balance first and returns `insufficient` (creating no invoice) when it can't cover the hour, and the hourly cron suspends on that signal (prepaid has no day-based grace). It also reports the real payment outcome instead of logging a "Deducted" success when `ApplyCredit` actually failed.
+
+### Changed
+- **Clearer product config labels** — mode-specific Module Settings fields are now prefixed with their mode so it's obvious in the WHMCS UI which billing mode they apply to: `[Monthly] Suspension Days` / `[Monthly] Termination Days` and `[Prepaid] Min Wallet Balance` / `[Prepaid] Initial Wallet Credit` / `[Prepaid] Initial Credit Mode` / `[Prepaid] Auto Top-Up Threshold` / `[Prepaid] Auto Top-Up Amount`. Descriptions spell out that the day-based fields are monthly-only and prepaid suspends by wallet balance. (Display text only — config-option positions and stored values are unchanged.)
+
 ## [2.4.2] - 2026-07-11
 
 > Module-only patch on top of platform **2.4.1** (ariel_1) — no API/platform change; the third digit tracks module iterations under SemVer.

--- a/crons/hostedai_hourly_cron.php
+++ b/crons/hostedai_hourly_cron.php
@@ -88,6 +88,7 @@ try {
         // idempotency check below (double-billing the same clock hour). API errors also
         // skip the balance check since we can't know the post-billing balance in that case.
         $skipBalanceCheck = false;
+        $walletInsufficient = false; // set when the wallet can't cover this hour's charge
         $shouldBill = ($teamHelper !== null);
 
         if (!$teamHelper) {
@@ -230,10 +231,15 @@ try {
                     $summary      = "Hourly usage — {$hourLabel} — Team {$team->teamid}";
                     $deductResult = $helper->createAndPayHourlyInvoice($team->uid, $totalCost, $summary, $lineItems);
 
-                    if ($deductResult['result'] !== 'success') {
-                        logActivity("Hourly cron: Deduction failed for TeamID {$team->teamid}: " . json_encode($deductResult));
-                    } else {
+                    if ($deductResult['result'] === 'success') {
                         logActivity("Hourly cron: Deducted \${$totalCost} from UID {$team->uid}, invoice #{$deductResult['invoiceid']}");
+                    } elseif ($deductResult['result'] === 'insufficient') {
+                        // Wallet can't cover this hour → suspend below (prepaid, no grace).
+                        // No invoice was created, so no unpayable debt accrues.
+                        $walletInsufficient = true;
+                        logActivity("Hourly cron: TeamID {$team->teamid} — wallet \${$deductResult['balance']} can't cover \${$deductResult['required']}; will suspend (insufficient funds)");
+                    } else {
+                        logActivity("Hourly cron: Deduction not paid for TeamID {$team->teamid}: " . json_encode($deductResult));
                     }
                 } else {
                     logActivity("Hourly cron: TeamID {$team->teamid} — zero usage this hour, no invoice");
@@ -270,13 +276,20 @@ try {
                     }
                 }
 
-                if ($balance <= $minBalance && $currentReason !== 'balance_zero') {
+                // Suspend when the wallet can no longer sustain the service: either it
+                // couldn't cover this hour's charge (insufficient funds — the common case,
+                // since an hourly charge is normally far above the min-balance floor), or
+                // the balance has drained to/below the floor. Prepaid has no day-based grace.
+                if (($walletInsufficient || $balance <= $minBalance) && $currentReason !== 'balance_zero') {
                     $helper->suspendTerminate_service($team->sid, $team->pid, 'ModuleSuspend');
                     Capsule::table('mod_hostdaiteam_details')
                         ->where('sid', $team->sid)
                         ->update(['suspended_reason' => 'balance_zero', 'updated_at' => date('Y-m-d H:i:s')]);
-                    logActivity("Hourly cron: Suspended service {$team->sid} (TeamID {$team->teamid}) — balance \${$balance} ≤ threshold \${$minBalance}");
-                } elseif ($balance > $minBalance && $balance <= $minBalance * 2) {
+                    $why = $walletInsufficient
+                        ? "wallet \${$balance} cannot cover the hourly charge"
+                        : "balance \${$balance} ≤ threshold \${$minBalance}";
+                    logActivity("Hourly cron: Suspended service {$team->sid} (TeamID {$team->teamid}) — {$why}");
+                } elseif (!$walletInsufficient && $balance > $minBalance && $balance <= $minBalance * 2) {
                     // Low balance warning — send at most once per 24 hours
                     $lastNotified = $team->low_balance_notified_at ?? null;
                     $hoursSince   = $lastNotified ? (time() - strtotime($lastNotified)) / 3600 : 999;

--- a/modules/servers/hostedai/hostedai.php
+++ b/modules/servers/hostedai/hostedai.php
@@ -8,7 +8,7 @@ if (!defined("WHMCS")) {
     die("This file cannot be accessed directly");
 }
 
-define('HOSTEDAI_MODULE_VERSION', '2.4.2');
+define('HOSTEDAI_MODULE_VERSION', '2.4.3');
 
 function hostedai_MetaData()
 {
@@ -219,16 +219,16 @@ function hostedai_ConfigOptions(array $params)
             'Description' => 'Login button target; blank = default panel.',
         ),
         'suspentionDays' => array(
-            'FriendlyName' => 'Suspension Days (monthly)',
+            'FriendlyName' => '[Monthly] Suspension Days',
             'Type' => 'text',
             'Size' => '25',
-            'Description' => 'Days overdue before auto-suspend. Blank = off. Monthly only.',
+            'Description' => 'MONTHLY mode only — ignored in prepaid. Days an invoice may stay unpaid before auto-suspend. Blank = off. (Prepaid suspends by wallet balance — see [Prepaid] Min Wallet Balance.)',
         ),
         'termminationDays' => array(
-            'FriendlyName' => 'Termination Days (monthly)',
+            'FriendlyName' => '[Monthly] Termination Days',
             'Type' => 'text',
             'Size' => '25',
-            'Description' => 'Days overdue before auto-terminate. Blank = off. Monthly only.',
+            'Description' => 'MONTHLY mode only — ignored in prepaid. Days an invoice may stay unpaid before auto-terminate (must already be suspended). Blank = off.',
         ),
         'billing_mode' => array(
             'FriendlyName' => 'Billing Mode',
@@ -237,38 +237,38 @@ function hostedai_ConfigOptions(array $params)
             'Description' => 'monthly = invoice at end of month; prepaid = deduct from wallet each hour',
         ),
         'min_balance' => array(
-            'FriendlyName' => 'Min Wallet Balance ($)',
+            'FriendlyName' => '[Prepaid] Min Wallet Balance ($)',
             'Type' => 'text',
             'Size' => '10',
             'Default' => '1.00',
-            'Description' => 'Suspend when wallet drops to or below this amount (prepaid mode only)',
+            'Description' => 'PREPAID mode only. Suspend once the wallet can no longer cover an hour of usage (or drops to/below this amount). No day-based grace in prepaid.',
         ),
         // NOTE: options below are APPEND-ONLY. WHMCS maps config options to
         // configoption{N} by position — never insert new options above this line
         // or existing products' saved values will shift.
         'initial_wallet_credit' => array(
-            'FriendlyName' => 'Initial Wallet Credit ($)',
+            'FriendlyName' => '[Prepaid] Initial Wallet Credit ($)',
             'Type' => 'text',
             'Size' => '10',
-            'Description' => 'On provision, seed the prepaid wallet up to this amount (0/blank = off).',
+            'Description' => 'PREPAID mode only. On provision, seed the wallet up to this amount (0/blank = off).',
         ),
         'initial_credit_mode' => array(
-            'FriendlyName' => 'Initial Credit Mode',
+            'FriendlyName' => '[Prepaid] Initial Credit Mode',
             'Type' => 'dropdown',
             'Options' => 'grant,invoice',
-            'Description' => 'grant = add credit for free (trial/demo); invoice = raise an Add Funds invoice the client must pay.',
+            'Description' => 'PREPAID mode only. grant = add credit for free (trial/demo); invoice = raise an Add Funds invoice the client must pay.',
         ),
         'auto_topup_threshold' => array(
-            'FriendlyName' => 'Auto Top-Up Threshold ($)',
+            'FriendlyName' => '[Prepaid] Auto Top-Up Threshold ($)',
             'Type' => 'text',
             'Size' => '10',
-            'Description' => 'When wallet drops below this, auto-raise a top-up invoice (0/blank = off). Set above Min Wallet Balance.',
+            'Description' => 'PREPAID mode only. When the wallet drops below this, auto-raise a top-up invoice (0/blank = off). Set above Min Wallet Balance.',
         ),
         'auto_topup_amount' => array(
-            'FriendlyName' => 'Auto Top-Up Amount ($)',
+            'FriendlyName' => '[Prepaid] Auto Top-Up Amount ($)',
             'Type' => 'text',
             'Size' => '10',
-            'Description' => 'Amount of the auto top-up (Add Funds) invoice.',
+            'Description' => 'PREPAID mode only. Amount of the auto top-up (Add Funds) invoice.',
         ),
 
     );

--- a/modules/servers/hostedai/lib/Helper.php
+++ b/modules/servers/hostedai/lib/Helper.php
@@ -467,6 +467,18 @@ class Helper
                 $i++;
             }
 
+            // Prepaid is pay-as-you-go: only bill what the wallet can cover. If the balance
+            // can't cover the full hour, do NOT create an unpayable invoice — signal
+            // 'insufficient' so the caller suspends (prepaid, no grace, no debt pile-up).
+            // WHMCS ApplyCredit is all-or-nothing: a full charge against a short balance
+            // fails entirely, which would otherwise leave the invoice unpaid and the wallet
+            // stuck above the suspend floor forever (the service would run for free).
+            $balance = $this->getClientCreditBalance($userId);
+            if ($balance !== null && $total > 0 && ($balance + 0.00001) < $total) {
+                logActivity("createAndPayHourlyInvoice: UID {$userId} balance \${$balance} < charge \${$total} — insufficient funds, not billing (suspend expected)");
+                return ['result' => 'insufficient', 'balance' => $balance, 'required' => $total];
+            }
+
             $invoice = localAPI('CreateInvoice', $params);
 
             if (!isset($invoice['result']) || $invoice['result'] !== 'success') {
@@ -478,7 +490,10 @@ class Helper
             $creditResult = localAPI('ApplyCredit', ['invoiceid' => $invoiceId, 'amount' => $total]);
             logActivity("Hourly deduction: UID={$userId} amount=\${$total} invoice=#{$invoiceId} items=" . count($items) . " credit=" . json_encode($creditResult));
 
-            return ['result' => 'success', 'invoiceid' => $invoiceId, 'credit_result' => $creditResult];
+            // Report the REAL payment outcome — 'success' only if ApplyCredit actually paid
+            // it. A created-but-unpaid invoice must not masquerade as a successful deduction.
+            $paid = isset($creditResult['result']) && $creditResult['result'] === 'success';
+            return ['result' => $paid ? 'success' : 'unpaid', 'invoiceid' => $invoiceId, 'credit_result' => $creditResult];
         } catch (Exception $e) {
             logActivity('createAndPayHourlyInvoice error: ' . $e->getMessage());
             return ['result' => 'error', 'message' => $e->getMessage()];


### PR DESCRIPTION
Patch release **2.4.3**.

**Bug:** a prepaid service whose wallet couldn't cover an hour's charge was **never suspended** — it ran for free while unpayable invoices piled up hourly. WHMCS `ApplyCredit` is all-or-nothing, so a full charge against a short balance failed entirely; the balance never reached the min-balance floor, so the `balance ≤ min` suspend never fired.

**Fix**
- `Helper::createAndPayHourlyInvoice()` checks the balance first and returns `insufficient` (creating **no** invoice) when it can't cover the hour, and reports the real payment outcome instead of a false `success` on `ApplyCredit` failure.
- Hourly cron suspends on the insufficient-funds signal (prepaid has no day-based grace).

**Also**
- Clearer Module Settings labels: mode prefixes `[Monthly]` / `[Prepaid]` + descriptions spelling out which billing mode each field applies to (display text only — config-option positions & stored values unchanged).
- `HOSTEDAI_MODULE_VERSION` 2.4.2 → 2.4.3; CHANGELOG `[2.4.3]`.

**Verified**
- New regression tests `TestPrepaidInsufficientFundsSuspend` (source guards + behavioral: $0-credit hour → `insufficient`, no invoice; funded hour → paid). Full suite **79 passed / 4 skipped** on WHMCS 9 / PHP 8.3.
- Live on sandbox: two prepaid teams (uid 125, 81) correctly moved to Suspended once their wallets couldn't cover the hour; no new invoices created after suspension.

Merge with a **merge commit** (not squash) to keep develop↔main history in sync.