### PR TITLE
fix(team): switch team-members paging to page=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Team members list no longer silently empties out** — `Helper::getTeamMembers()` requested `page=1`, the old 1-based first page. The platform's team-members pagination is now 0-based (page=0 is first); `page=1` still returns HTTP 200 but with `members: null` for any team with itemsPerPage (50) or fewer members, so the client-area member table went blank with no error. Switched to `page=0`, which returns the first page under both the old and new pagination scheme.
+
 ## [2.4.3] - 2026-07-11
 
 ### Fixed

--- a/modules/servers/hostedai/lib/Helper.php
+++ b/modules/servers/hostedai/lib/Helper.php
@@ -136,7 +136,11 @@ class Helper
     public function getTeamMembers($teamid)
     {
         try {
-            $endPoint = 'team/' . $teamid . '/members?page=1&itemsPerPage=50';
+            // page=0 is the first page on both 2.4.1 and 2.4.2 (paging went zero-based in
+            // 2.4.2 — see API Changelogs 2.4.2, "Team Member Paging Is Now Zero-Based").
+            // page=1 still returns HTTP 200 on 2.4.2, but with an empty members list for
+            // any team with itemsPerPage or fewer members — silently, no error.
+            $endPoint = 'team/' . $teamid . '/members?page=0&itemsPerPage=50';
             $curlResponse = $this->curlCall("GET", "getTeamMembers", $endPoint, '');
 
             return $curlResponse;


### PR DESCRIPTION
## Summary
- The platform's `team/{team_id}/members` pagination went zero-based (see the 2.4.2 API changelog, "Team Member Paging Is Now Zero-Based"). `Helper::getTeamMembers()` was requesting `page=1`, which now returns HTTP 200 with `members: null` for any team with 50 or fewer members — the client-area member table went blank with no error.
- Switched to `page=0`, which returns the first page under both the old and new pagination scheme, so it's safe to deploy independently of any platform upgrade.